### PR TITLE
Add support for matching on any search token

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -14,7 +14,7 @@ export interface SearchApiIndex {
 
   /**
    * Finds uids that have been mapped to the set of tokens specified.
-   * Only uids that have been mapped to all tokens will be returned.
+   * Only uids that have been mapped to all tokens will be returned by default.
    *
    * @param tokens Array of searchable tokens (e.g. ["long", "road"])
    * @return Array of uids that have been associated with the set of search tokens

--- a/src/util/SearchUtility.js
+++ b/src/util/SearchUtility.js
@@ -18,6 +18,7 @@ export default class SearchUtility implements SearchApiIndex {
   _indexMode: IndexMode;
   _tokenizePattern: RegExp;
   _caseSensitive: boolean;
+  _matchAnyToken: boolean;
   _searchIndex: SearchIndex;
   _uids: UidMap;
 
@@ -27,21 +28,25 @@ export default class SearchUtility implements SearchApiIndex {
    * @param indexMode See #setIndexMode
    * @param tokenizePattern See #setTokenizePattern
    * @param caseSensitive See #setCaseSensitive
+   * @param matchAnyToken See #setMatchAnyToken
    */
   constructor(
     {
       indexMode = INDEX_MODES.ALL_SUBSTRINGS,
       tokenizePattern = /\s+/,
-      caseSensitive = false
+      caseSensitive = false,
+      matchAnyToken = false
     }: {
       indexMode?: IndexMode,
       tokenizePattern?: RegExp,
-      caseSensitive?: boolean
+      caseSensitive?: boolean,
+      matchAnyToken?: boolean
     } = {}
   ) {
     this._indexMode = indexMode;
     this._tokenizePattern = tokenizePattern;
     this._caseSensitive = caseSensitive;
+    this._matchAnyToken = matchAnyToken;
 
     this._searchIndex = new SearchIndex();
     this._uids = {};
@@ -69,6 +74,13 @@ export default class SearchUtility implements SearchApiIndex {
   }
 
   /**
+   * Returns a constant representing the current match-any-token bit.
+   */
+  getMatchAnyToken(): boolean {
+    return this._matchAnyToken;
+  }
+
+  /**
    * Adds or updates a uid in the search index and associates it with the specified text.
    * Note that at this time uids can only be added or updated in the index, not removed.
    *
@@ -93,11 +105,12 @@ export default class SearchUtility implements SearchApiIndex {
 
   /**
    * Searches the current index for the specified query text.
-   * Only uids matching all of the words within the text will be accepted.
+   * Only uids matching all of the words within the text will be accepted,
+   * unless matchAny is set to true.
    * If an empty query string is provided all indexed uids will be returned.
    *
-   * Document searches are case-insensitive (e.g. "search" will match "Search").
-   * Document searches use substring matching (e.g. "na" and "me" will both match "name").
+   * Document searches are case-insensitive by default (e.g. "search" will match "Search").
+   * Document searches use substring matching by default (e.g. "na" and "me" will both match "name").
    *
    * @param query Searchable query text
    * @return Array of uids
@@ -108,7 +121,7 @@ export default class SearchUtility implements SearchApiIndex {
     } else {
       var tokens: Array<string> = this._tokenize(this._sanitize(query));
 
-      return this._searchIndex.search(tokens);
+      return this._searchIndex.search(tokens, this._matchAnyToken);
     }
   };
 
@@ -138,6 +151,13 @@ export default class SearchUtility implements SearchApiIndex {
    */
   setCaseSensitive(caseSensitive: boolean): void {
     this._caseSensitive = caseSensitive;
+  }
+
+  /**
+   * Sets a new match-any-token bit
+   */
+  setMatchAnyToken(matchAnyToken: boolean): void {
+    this._matchAnyToken = matchAnyToken;
   }
 
   /**

--- a/src/util/SearchUtility.test.js
+++ b/src/util/SearchUtility.test.js
@@ -55,17 +55,20 @@ function init(
   {
     indexMode,
     tokenizePattern,
-    caseSensitive
+    caseSensitive,
+    matchAnyToken
   }: {
     indexMode?: IndexMode,
     tokenizePattern?: RegExp,
-    caseSensitive?: boolean
+    caseSensitive?: boolean,
+    matchAnyToken?: boolean
   } = {}
 ) {
   const searchUtility = new SearchUtility({
     indexMode,
     tokenizePattern,
-    caseSensitive
+    caseSensitive,
+    matchAnyToken
   });
 
   documents.forEach(doc => {
@@ -110,6 +113,15 @@ test("SearchUtility should return documents ids only if document matches all tok
   ids = await searchUtility.search("three document"); // Spans multiple fields
   expect(ids.length).toBe(1);
   expect(ids[0]).toBe(3);
+  done();
+});
+
+test("SearchUtility should return matching documents for any token, if specified", async done => {
+  const searchUtility = init({ matchAnyToken: true });
+  let ids = await searchUtility.search("first two second");
+  expect(ids.length).toBe(2);
+  expect(ids[0]).toBe(2); // The second document has most matches
+  expect(ids[1]).toBe(1);
   done();
 });
 


### PR DESCRIPTION
This PR adds support for search queries that can match on any search token, i.e. OR queries.

Queries are sorted according to the document that has the most token matches.

---

Hey @bvaughn, thanks for a great and light search package! I'm using it through `redux-search` and I was looking for a way to do OR queries, but I couldn't find any existing solution. This PR is a super-simple solution that simply allows matching on *any* token instead of *all* tokens.

I simply added another flag to the search utility, inspired by the "case sensitive" flag.