### PR TITLE
Move flow-bin to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,10 +68,10 @@
     "rimraf": "^2.5.0",
     "watch": "^1.0.2",
     "webpack": "^1.12.9",
-    "worker-loader": "^0.8.1"
+    "worker-loader": "^0.8.1",
+    "flow-bin": "^0.50.0"
   },
   "dependencies": {
-    "flow-bin": "^0.50.0",
     "uuid": "^2.0.1"
   }
 }


### PR DESCRIPTION
Hi Brian, thanks for this package! I believe `flow-bin` should be in `devDependencies` instead of regular `dependencies`, but correct me if I am wrong :)