### PR TITLE
Adding maxSubstringLength field

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/benchmarks/.*
+.*/node_modules/immutable/dist/immutable.js.flow
 
 [include]
 src/**/*.js

--- a/package.json
+++ b/package.json
@@ -62,14 +62,14 @@
     "eslint-config-prettier": "^2.3.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-prettier": "^2.1.2",
+    "flow-bin": "^0.125.0",
     "immutable": "^3.8.1",
     "jest": "^22.1.1",
     "prettier": "^1.5.3",
     "rimraf": "^2.5.0",
     "watch": "^1.0.2",
     "webpack": "^1.12.9",
-    "worker-loader": "^0.8.1",
-    "flow-bin": "^0.50.0"
+    "worker-loader": "^0.8.1"
   },
   "dependencies": {
     "uuid": "^2.0.1"

--- a/src/SearchApi.js
+++ b/src/SearchApi.js
@@ -17,12 +17,14 @@ export default class SearchApi {
       caseSensitive,
       indexMode,
       matchAnyToken,
-      tokenizePattern
+      tokenizePattern,
+      maxDepth
     }: {
       caseSensitive?: boolean,
       indexMode?: IndexMode,
       matchAnyToken?: boolean,
-      tokenizePattern?: RegExp
+      tokenizePattern?: RegExp,
+      maxDepth?: number
     } = {}
   ) {
     // Based on https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
@@ -32,14 +34,16 @@ export default class SearchApi {
         indexMode,
         matchAnyToken,
         tokenizePattern,
-        caseSensitive
+        caseSensitive,
+        maxDepth
       });
     } else {
       this._search = new SearchUtility({
         indexMode,
         matchAnyToken,
         tokenizePattern,
-        caseSensitive
+        caseSensitive,
+        maxDepth
       });
     }
   }

--- a/src/SearchApi.js
+++ b/src/SearchApi.js
@@ -18,13 +18,13 @@ export default class SearchApi {
       indexMode,
       matchAnyToken,
       tokenizePattern,
-      maxDepth
+      maxSubstringLength
     }: {
       caseSensitive?: boolean,
       indexMode?: IndexMode,
       matchAnyToken?: boolean,
       tokenizePattern?: RegExp,
-      maxDepth?: number
+      maxSubstringLength?: number
     } = {}
   ) {
     // Based on https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
@@ -35,7 +35,7 @@ export default class SearchApi {
         matchAnyToken,
         tokenizePattern,
         caseSensitive,
-        maxDepth
+        maxSubstringLength
       });
     } else {
       this._search = new SearchUtility({
@@ -43,7 +43,7 @@ export default class SearchApi {
         matchAnyToken,
         tokenizePattern,
         caseSensitive,
-        maxDepth
+        maxSubstringLength
       });
     }
   }

--- a/src/util/SearchUtility.js
+++ b/src/util/SearchUtility.js
@@ -85,7 +85,7 @@ export default class SearchUtility implements SearchApiIndex {
   }
 
   /**
-   * Returns a constant representing the current tokenize pattern.
+   * Returns the maximum length a substring will be for ALL_SUBSTRINGS index mode.
    */
   getMaxSubstringLength(): number {
     return this._maxSubstringLength;
@@ -172,7 +172,7 @@ export default class SearchUtility implements SearchApiIndex {
   }
 
   /**
-   * Sets a new tokenize pattern (regular expression)
+   * Sets the new max substring length for ALL_SUBSTRINGS index mode.
    */
   setMaxSubstringLength(maxSubstringLength: number): void {
     this._maxSubstringLength = maxSubstringLength;

--- a/src/util/SearchUtility.test.js
+++ b/src/util/SearchUtility.test.js
@@ -47,13 +47,13 @@ const documentH = fromJS({
 });
 
 const documents = [
-  //documentA,
-  //documentB,
-  //documentC,
-  //documentD,
-  //documentE,
-  //documentF,
-  //documentG,
+  documentA,
+  documentB,
+  documentC,
+  documentD,
+  documentE,
+  documentF,
+  documentG,
   documentH
 ];
 
@@ -290,22 +290,20 @@ test("SearchUtility should support custom tokenizer pattern", async done => {
   expect(await searchUtility.search("6o")).toEqual([6]);
   done();
 });
-test.only(
-  "SearchUtility should use maxSubstringLength for ALL_SUBSTRINGS index mode",
-  async done => {
-    const searchUtility = init({
-      indexMode: INDEX_MODES.ALL_SUBSTRINGS,
-      maxSubstringLength: 20
-    });
-    expect(
-      (await searchUtility.search("Verylongstringwithoutdelimiter")).length
-    ).toBe(0);
-    expect(await searchUtility.search("verylong")).toEqual([8]);
-    expect(await searchUtility.search("without")).toEqual([8]);
-    expect(await searchUtility.search("delimiter")).toEqual([8]);
-    done();
-  }
-);
+test("SearchUtility should use maxSubstringLength for ALL_SUBSTRINGS index mode", async done => {
+  const searchUtility = init({
+    indexMode: INDEX_MODES.ALL_SUBSTRINGS,
+    maxSubstringLength: 10
+  });
+  expect(
+    (await searchUtility.search("Verylongstringwithoutdelimiter")).length
+  ).toBe(0);
+  expect(await searchUtility.search("verylong")).toEqual([8]);
+  expect(await searchUtility.search("without")).toEqual([8]);
+  expect(await searchUtility.search("delimiter")).toEqual([8]);
+  expect((await searchUtility.search("withoutdelimiter")).length).toBe(0);
+  done();
+});
 test("SearchUtility should ignore maxSubstringLength for PREFIXES index mode", async done => {
   const searchUtility = init({
     indexMode: INDEX_MODES.PREFIXES,

--- a/src/util/SearchUtility.test.js
+++ b/src/util/SearchUtility.test.js
@@ -47,13 +47,13 @@ const documentH = fromJS({
 });
 
 const documents = [
-  documentA,
-  documentB,
-  documentC,
-  documentD,
-  documentE,
-  documentF,
-  documentG,
+  //documentA,
+  //documentB,
+  //documentC,
+  //documentD,
+  //documentE,
+  //documentF,
+  //documentG,
   documentH
 ];
 
@@ -63,13 +63,13 @@ function init(
     tokenizePattern,
     caseSensitive,
     matchAnyToken,
-    maxDepth
+    maxSubstringLength
   }: {
     indexMode?: IndexMode,
     tokenizePattern?: RegExp,
     caseSensitive?: boolean,
     matchAnyToken?: boolean,
-    maxDepth?: number
+    maxSubstringLength?: number
   } = {}
 ) {
   const searchUtility = new SearchUtility({
@@ -77,7 +77,7 @@ function init(
     tokenizePattern,
     caseSensitive,
     matchAnyToken,
-    maxDepth
+    maxSubstringLength
   });
 
   documents.forEach(doc => {
@@ -290,12 +290,39 @@ test("SearchUtility should support custom tokenizer pattern", async done => {
   expect(await searchUtility.search("6o")).toEqual([6]);
   done();
 });
-test("SearchUtility should support max depth value", async done => {
+test.only(
+  "SearchUtility should use maxSubstringLength for ALL_SUBSTRINGS index mode",
+  async done => {
+    const searchUtility = init({
+      indexMode: INDEX_MODES.ALL_SUBSTRINGS,
+      maxSubstringLength: 20
+    });
+    expect(
+      (await searchUtility.search("Verylongstringwithoutdelimiter")).length
+    ).toBe(0);
+    expect(await searchUtility.search("verylong")).toEqual([8]);
+    expect(await searchUtility.search("without")).toEqual([8]);
+    expect(await searchUtility.search("delimiter")).toEqual([8]);
+    done();
+  }
+);
+test("SearchUtility should ignore maxSubstringLength for PREFIXES index mode", async done => {
+  const searchUtility = init({
+    indexMode: INDEX_MODES.PREFIXES,
+    maxSubstringLength: 10
+  });
+  expect(await searchUtility.search("Verylongstringwithout")).toEqual([8]);
+  expect((await searchUtility.search("Verylongst")).length).toBe(1);
+  done();
+});
+test("SearchUtility should ignore maxSubstringLength for EXACT_WORDS index mode", async done => {
   const searchUtility = init({
     indexMode: INDEX_MODES.EXACT_WORDS,
-    maxDepth: 10
+    maxSubstringLength: 10
   });
-  expect((await searchUtility.search("Verylongstringwithout")).length).toBe(0);
-  expect(await searchUtility.search("Verylongst")).toEqual([8]);
+  expect(await searchUtility.search("Verylongstringwithoutdelimiter")).toEqual([
+    8
+  ]);
+  expect((await searchUtility.search("Verylongst")).length).toBe(0);
   done();
 });

--- a/src/util/SearchUtility.test.js
+++ b/src/util/SearchUtility.test.js
@@ -40,6 +40,11 @@ const documentG = fromJS({
   name: "Seven",
   description: "ქართული ენა"
 });
+const documentH = fromJS({
+  id: 8,
+  name: "Eight",
+  description: "Verylongstringwithoutdelimiter"
+});
 
 const documents = [
   documentA,
@@ -48,7 +53,8 @@ const documents = [
   documentD,
   documentE,
   documentF,
-  documentG
+  documentG,
+  documentH
 ];
 
 function init(
@@ -56,19 +62,22 @@ function init(
     indexMode,
     tokenizePattern,
     caseSensitive,
-    matchAnyToken
+    matchAnyToken,
+    maxDepth
   }: {
     indexMode?: IndexMode,
     tokenizePattern?: RegExp,
     caseSensitive?: boolean,
-    matchAnyToken?: boolean
+    matchAnyToken?: boolean,
+    maxDepth?: number
   } = {}
 ) {
   const searchUtility = new SearchUtility({
     indexMode,
     tokenizePattern,
     caseSensitive,
-    matchAnyToken
+    matchAnyToken,
+    maxDepth
   });
 
   documents.forEach(doc => {
@@ -279,5 +288,14 @@ test("SearchUtility should support custom tokenizer pattern", async done => {
   });
   expect(await searchUtility.search("sexto")).toEqual([6]);
   expect(await searchUtility.search("6o")).toEqual([6]);
+  done();
+});
+test("SearchUtility should support max depth value", async done => {
+  const searchUtility = init({
+    indexMode: INDEX_MODES.EXACT_WORDS,
+    maxDepth: 10
+  });
+  expect((await searchUtility.search("Verylongstringwithout")).length).toBe(0);
+  expect(await searchUtility.search("Verylongst")).toEqual([8]);
   done();
 });

--- a/src/worker/SearchWorkerLoader.js
+++ b/src/worker/SearchWorkerLoader.js
@@ -39,14 +39,14 @@ export default class SearchWorkerLoader implements SearchApiIndex {
       indexMode,
       matchAnyToken,
       tokenizePattern,
-      maxDepth,
+      maxSubstringLength,
       WorkerClass
     }: {
       caseSensitive?: boolean,
       indexMode?: IndexMode,
       matchAnyToken?: boolean,
       tokenizePattern?: RegExp,
-      maxDepth?: number,
+      maxSubstringLength?: number,
       WorkerClass?: Class<Worker>
     } = {}
   ) {
@@ -106,11 +106,11 @@ export default class SearchWorkerLoader implements SearchApiIndex {
       });
     }
 
-    // Override default :maxDepth if a specific one has been requested
-    if (maxDepth) {
+    // Override default :maxSubstringLength if a specific one has been requested
+    if (maxSubstringLength) {
       this._worker.postMessage({
-        method: "setMaxDepth",
-        maxDepth
+        method: "setMaxSubstringLength",
+        maxSubstringLength
       });
     }
   }

--- a/src/worker/SearchWorkerLoader.js
+++ b/src/worker/SearchWorkerLoader.js
@@ -39,12 +39,14 @@ export default class SearchWorkerLoader implements SearchApiIndex {
       indexMode,
       matchAnyToken,
       tokenizePattern,
+      maxDepth,
       WorkerClass
     }: {
       caseSensitive?: boolean,
       indexMode?: IndexMode,
       matchAnyToken?: boolean,
       tokenizePattern?: RegExp,
+      maxDepth?: number,
       WorkerClass?: Class<Worker>
     } = {}
   ) {
@@ -101,6 +103,14 @@ export default class SearchWorkerLoader implements SearchApiIndex {
       this._worker.postMessage({
         method: "setTokenizePattern",
         tokenizePattern
+      });
+    }
+
+    // Override default :maxDepth if a specific one has been requested
+    if (maxDepth) {
+      this._worker.postMessage({
+        method: "setMaxDepth",
+        maxDepth
       });
     }
   }

--- a/src/worker/SearchWorkerLoader.test.js
+++ b/src/worker/SearchWorkerLoader.test.js
@@ -49,6 +49,10 @@ class StubWorker {
         const { tokenizePattern } = props;
         this._setTokenizePatternQueue.push({ tokenizePattern });
         break;
+      case "setMaxDepth":
+        const { maxDepth } = props;
+        this._setTokenizePatternQueue.push({ maxDepth });
+        break;
     }
   }
 
@@ -211,4 +215,13 @@ test("SearchWorkerLoader should pass the specified :matchAnyToken bit to the Wor
   });
   expect(search._worker._setMatchAnyTokenQueue.length).toBe(1);
   expect(search._worker._setMatchAnyTokenQueue[0].matchAnyToken).toBe(true);
+});
+
+test("SearchWorkerLoader should pass the specified :maxDpetgh to the WorkerClass", () => {
+  const search = new SearchWorkerLoader({
+    maxDepth: 100,
+    WorkerClass: StubWorker
+  });
+  expect(search._worker._setTokenizePatternQueue.length).toBe(1);
+  expect(search._worker._setTokenizePatternQueue[0].maxDepth).toBe(100);
 });

--- a/src/worker/SearchWorkerLoader.test.js
+++ b/src/worker/SearchWorkerLoader.test.js
@@ -49,9 +49,9 @@ class StubWorker {
         const { tokenizePattern } = props;
         this._setTokenizePatternQueue.push({ tokenizePattern });
         break;
-      case "setMaxDepth":
-        const { maxDepth } = props;
-        this._setTokenizePatternQueue.push({ maxDepth });
+      case "setMaxSubstringLength":
+        const { maxSubstringLength } = props;
+        this._setTokenizePatternQueue.push({ maxSubstringLength });
         break;
     }
   }
@@ -219,9 +219,11 @@ test("SearchWorkerLoader should pass the specified :matchAnyToken bit to the Wor
 
 test("SearchWorkerLoader should pass the specified :maxDpetgh to the WorkerClass", () => {
   const search = new SearchWorkerLoader({
-    maxDepth: 100,
+    maxSubstringLength: 100,
     WorkerClass: StubWorker
   });
   expect(search._worker._setTokenizePatternQueue.length).toBe(1);
-  expect(search._worker._setTokenizePatternQueue[0].maxDepth).toBe(100);
+  expect(search._worker._setTokenizePatternQueue[0].maxSubstringLength).toBe(
+    100
+  );
 });

--- a/src/worker/Worker.js
+++ b/src/worker/Worker.js
@@ -48,10 +48,10 @@ self.addEventListener(
 
         searchUtility.setTokenizePattern(tokenizePattern);
         break;
-      case "setMaxDepth":
-        const { maxDepth } = data;
+      case "setMaxSubstringLength":
+        const { maxSubstringLength } = data;
 
-        searchUtility.setMaxDepth(maxDepth);
+        searchUtility.setMaxSubstringLength(maxSubstringLength);
         break;
     }
   },

--- a/src/worker/Worker.js
+++ b/src/worker/Worker.js
@@ -48,6 +48,11 @@ self.addEventListener(
 
         searchUtility.setTokenizePattern(tokenizePattern);
         break;
+      case "setMaxDepth":
+        const { maxDepth } = data;
+
+        searchUtility.setMaxDepth(maxDepth);
+        break;
     }
   },
   false

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,9 +1902,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.50.0:
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.50.0.tgz#d4cdb2430dee1a3599f0eb6fe551146e3027256a"
+flow-bin@^0.125.0:
+  version "0.125.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.125.1.tgz#7edbc71e7dc39ddef18086ef75c714bbf1c5917f"
+  integrity sha512-jEury9NTXylxQEOAXLWEE945BjBwYcMwwKVnb+5XORNwMQE7i5hQYF0ysYfsaaYOa7rW/U16rHBfwLuaZfWV7A==
 
 for-in@^0.1.5:
   version "0.1.6"


### PR DESCRIPTION
`js-worker-search` default indexing strategy is to create all substrings of a token. This takes `O(n^2)` in memory which can cause the browser to crash.

To prevent this, I added a new parameter called `maxLength`. It ensures there are no tokens larger than this substring by splitting at that length.

Some additional notes in this PR:
- Upgraded flow to the latest version to support `Array.flat`
- This caused a flow error in immutable (https://github.com/facebook/draft-js/issues/950) requiring changing our flowconfig