### PR TITLE
Updated uuid version to an ESM friendly version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 -----
-
+#### 2.0.0
+* Bumped uuid from 2.0.1 to 8.3.2 to support ES modules 
+  
 #### 1.4.1
 * Removed source maps from inline worker blob to avoid errors ([@jahed](https://github.com/jahed) - [#23](https://github.com/bvaughn/js-worker-search/pull/23))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-worker-search",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "description": "JavaScript client-side search API with web-worker support",
   "author": "Brian Vaughn (brian.david.vaughn@gmail.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-worker-search",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "JavaScript client-side search API with web-worker support",
   "author": "Brian Vaughn (brian.david.vaughn@gmail.com)",
   "license": "MIT",
@@ -72,6 +72,6 @@
     "flow-bin": "^0.50.0"
   },
   "dependencies": {
-    "uuid": "^2.0.1"
+    "uuid": "^8.3.2"
   }
 }

--- a/src/worker/SearchWorkerLoader.js
+++ b/src/worker/SearchWorkerLoader.js
@@ -1,6 +1,6 @@
 /** @flow */
 
-import uuid from "uuid";
+import { v4 as uuidv4 } from "uuid";
 
 import type { IndexMode } from "../util";
 import type { SearchApiIndex } from "../types";
@@ -135,7 +135,7 @@ export default class SearchWorkerLoader implements SearchApiIndex {
    */
   search = (query: string): Promise<Array<any>> => {
     return new Promise((resolve: ResolveFn, reject: RejectFn) => {
-      const callbackId = uuid.v4();
+      const callbackId = uuidv4();
       const data = {
         callbackId,
         complete: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4403,10 +4403,6 @@ util@0.10.3, util@^0.10.3:
   dependencies:
     inherits "2.0.1"
 
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
@@ -4414,6 +4410,11 @@ uuid@^3.0.0:
 uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8flags@^2.0.10:
   version "2.0.11"


### PR DESCRIPTION
We're trying to use this package with vitejs, however, uuid v2.0.1 is too old and doesn't have an ESM version. This tiny PR updates the version to 8.3.2